### PR TITLE
Fix the bug with dragging cursors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 2.5.8
+* Fix the bug with dragging cursors
+
 ## 2.5.7
 * Fix rendering visual when scroll is enabled. Fix scroll arrows not being clicked
 * Remove range header font size restrictions

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "powerbi-visuals-timeline",
-  "version": "2.5.7.0",
+  "version": "2.5.8.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "powerbi-visuals-timeline",
-      "version": "2.5.7.0",
+      "version": "2.5.8.0",
       "license": "MIT",
       "dependencies": {
         "@typescript-eslint/eslint-plugin": "^7.17.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "powerbi-visuals-timeline",
-  "version": "2.5.7.0",
+  "version": "2.5.8.0",
   "description": "Timeline slicer is a graphical date range selector used as a filtering component in the report canvas",
   "repository": {
     "type": "git",

--- a/pbiviz.json
+++ b/pbiviz.json
@@ -1,10 +1,10 @@
 {
   "visual": {
     "name": "Timeline",
-    "displayName": "Timeline 2.5.7.0",
+    "displayName": "Timeline 2.5.8.0",
     "guid": "Timeline1447991079100",
     "visualClassName": "Timeline",
-    "version": "2.5.7.0",
+    "version": "2.5.8.0",
     "description": "Timeline slicer is a graphical date range selector used as a filtering component in the report canvas",
     "supportUrl": "https://community.powerbi.com",
     "gitHubUrl": "https://github.com/Microsoft/powerbi-visuals-timeline"

--- a/src/timeLine.ts
+++ b/src/timeLine.ts
@@ -1141,8 +1141,7 @@ export class Timeline implements powerbiVisualsApi.extensibility.visual.IVisual 
     }
 
     public onCursorDrag(event: D3DragEvent<any, ICursorDataPoint, ICursorDataPoint>, currentCursor: ICursorDataPoint): void {
-        const mouseEvent: MouseEvent = event.sourceEvent;
-        const cursorOverElement: ITimelineCursorOverElement = this.findCursorOverElement(mouseEvent.x);
+        const cursorOverElement: ITimelineCursorOverElement = this.findCursorOverElement(event.x);
 
         if (!cursorOverElement) {
             return;


### PR DESCRIPTION
**Bug Description:**
- **Issue:** When dragging cursors, the current cursor position was computed incorrectly.
- **Cause:** The computation relied on the initial cursor position, leading to a misinterpretation of cursor movement.
- **Effect:** This caused the cursor to erroneously register as always moving left or right, resulting in continuous updates, even when the mouse was stationary.

